### PR TITLE
Playlists playback support.

### DIFF
--- a/Plex/source/HomeScreenDataLoader.brs
+++ b/Plex/source/HomeScreenDataLoader.brs
@@ -41,6 +41,7 @@ Function createHomeScreenDataLoader(listener)
         { title: "Channels", key: "channels" },
         { title: "Library Sections", key: "sections" },
         { title: "On Deck", key: "on_deck" },
+        { title: "Playlists", key: "playlists" },
         { title: "Now Playing", key: "now_playing" },
         { title: "Recently Added", key: "recently_added" },
         { title: "Queue", key: "queue" },
@@ -232,7 +233,24 @@ Sub homeCreateServerRequests(server As Object, startRequests As Boolean, refresh
             m.Listener.OnDataLoaded(m.RowIndexes[row], [], 0, 0, true)
         end if
     end if
-
+    
+    ' Request playlists
+    row = "playlists"
+    if rowkey = invalid or rowkey = row then
+        view = RegRead("row_visibility_playlists", "preferences", "")
+        if view <> "hidden" then
+            if view <> "owned" or (view = "owned" and server.owned) then 
+                playlists = CreateObject("roAssociativeArray")
+                playlists.server = server
+                playlists.key = "/playlists"
+                playlists.connectionUrl = connectionUrl
+                playlists.requestType = "row"
+                m.AddOrStartRequest(playlists, m.RowIndexes[row], startRequests)
+            end if
+        else
+            m.Listener.OnDataLoaded(m.RowIndexes[row], [], 0, 0, true)
+        end if
+    end if
 
     ' Request recently added
     ' even though the access is granted for shared users, the results seem to be ZERO - ljunkie (maybe they are adding this to the PMS?)
@@ -632,6 +650,8 @@ Sub homeOnUrlEvent(msg, requestContext)
                 item.ShortDescriptionLine2 = "Music section" + serverStr
             else if item.Type = "photo" then
                 item.ShortDescriptionLine2 = "Photo section" + serverStr
+            else if item.Type = "playlist" then
+                item.ShortDescriptionLine2 = "Playlists" + serverStr
             else
                 Debug("Skipping unsupported section type: " + tostr(item.Type))
                 add = false
@@ -1022,6 +1042,8 @@ Sub homeRefreshData()
     ' these could be out of order due to multiple PMS's -- however we must refresh these (no great fix for this yet)
     m.contentArray[m.RowIndexes["on_deck"]].refreshContent = []
     m.contentArray[m.RowIndexes["on_deck"]].loadedServers.Clear()
+    m.contentArray[m.RowIndexes["playlists"]].refreshContent = []
+    m.contentArray[m.RowIndexes["playlists"]].loadedServers.Clear()
     m.contentArray[m.RowIndexes["now_playing"]].refreshContent = []
     m.contentArray[m.RowIndexes["now_playing"]].loadedServers.Clear()
     m.contentArray[m.RowIndexes["recently_added"]].refreshContent = []
@@ -1050,6 +1072,7 @@ Sub homeOnMyPlexChange()
         m.RemoveFromRowIf(m.RowIndexes["channels"], IsMyPlexServer)
         m.RemoveFromRowIf(m.RowIndexes["now_playing"], IsMyPlexServer)
         m.RemoveFromRowIf(m.RowIndexes["on_deck"], IsMyPlexServer)
+        m.RemoveFromRowIf(m.RowIndexes["playlists"], IsMyPlexServer)
         m.RemoveFromRowIf(m.RowIndexes["recently_added"], IsMyPlexServer)
         m.RemoveFromRowIf(m.RowIndexes["misc"], IsMyPlexServer)
         m.RemoveFromRowIf(m.RowIndexes["queue"], AlwaysTrue)
@@ -1062,6 +1085,7 @@ Sub homeRemoveInvalidServers()
     m.RemoveFromRowIf(m.RowIndexes["sections"], IsInvalidServer)
     m.RemoveFromRowIf(m.RowIndexes["channels"], IsInvalidServer)
     m.RemoveFromRowIf(m.RowIndexes["on_deck"], IsInvalidServer)
+    m.RemoveFromRowIf(m.RowIndexes["playlists"], IsInvalidServer)
     m.RemoveFromRowIf(m.RowIndexes["now_playing"], IsInvalidServer)
     m.RemoveFromRowIf(m.RowIndexes["recently_added"], IsInvalidServer)
     m.RemoveFromRowIf(m.RowIndexes["misc"], IsInvalidServer)

--- a/Plex/source/MetadataUtils.brs
+++ b/Plex/source/MetadataUtils.brs
@@ -74,7 +74,7 @@ Function createBaseMetadata(container, item, thumb=invalid) As Object
 
     sizes = ImageSizes(container.ViewGroup, item@type)
     if thumb = invalid then
-        thumb = firstOf(item@thumb, item@parentThumb, item@grandparentThumb, container.xml@thumb)
+        thumb = firstOf(item@thumb, item@parentThumb, item@grandparentThumb, container.xml@thumb, item@composite)
     end if
 
     if thumb <> invalid AND thumb <> "" AND server <> invalid then

--- a/Plex/source/PlexContainer.brs
+++ b/Plex/source/PlexContainer.brs
@@ -123,6 +123,8 @@ Sub containerParseXml()
             metadata = newPhotoMetadata(m, n, m.ParseDetails)
         else if n.GetName() = "Setting" then
             metadata = newSettingMetadata(m, n)
+        else if nodeType = "playlist" then
+            metadata = newPlaylistsMetadata(m, n)
         else
             metadata = newDirectoryMetadata(m, n)
         end if
@@ -133,7 +135,7 @@ Sub containerParseXml()
         ' if the PMS starts giving out generic thumbs, I'll have to repace with the crazy logic/regex
 
         if RegRead("rf_custom_thumbs", "preferences","enabled") = "enabled" then
-            rfHasThumb = firstof(n@thumb, n@grandparentThumb, n@parentThumb)
+            rfHasThumb = firstof(n@thumb, n@grandparentThumb, n@parentThumb, n@composite)
            ' any other resources we want to override below
             re = CreateObject("roRegex", "/:/resources/actor-icon|resources/Book1.png", "") 
             ' this has mixed results - really the channel provider should be adding custom thumbs for every directory instead of the base channel thumb

--- a/Plex/source/PreferenceScreen.brs
+++ b/Plex/source/PreferenceScreen.brs
@@ -2097,6 +2097,7 @@ Function createHomeScreenPrefsScreen(viewController) As Object
         { title: "Channels", key: "channels" },
         { title: "Library Sections", key: "sections" },
         { title: "On Deck", key: "on_deck" },
+        { title: "Playlistsk", key: "playlists" },
         { title: "Now Playing", key: "now_playing" },
         { title: "Recently Added", key: "recently_added" },
         { title: "Queue", key: "queue" },

--- a/Plex/source/PreferenceScreen.brs
+++ b/Plex/source/PreferenceScreen.brs
@@ -2076,6 +2076,11 @@ Function createHomeScreenPrefsScreen(viewController) As Object
         heading: "Show On Deck items on the home screen",
         default: ""
     }
+    obj.Prefs["row_visibility_playlists"] = {
+        values: valuesShared,
+        heading: "Show Playlist items on the home screen",
+        default: ""
+    }
     obj.Prefs["row_visibility_recentlyadded"] = {
         values: valuesShared,
         heading: "Show recently added items on the home screen",
@@ -2097,7 +2102,7 @@ Function createHomeScreenPrefsScreen(viewController) As Object
         { title: "Channels", key: "channels" },
         { title: "Library Sections", key: "sections" },
         { title: "On Deck", key: "on_deck" },
-        { title: "Playlistsk", key: "playlists" },
+        { title: "Playlists", key: "playlists" },
         { title: "Now Playing", key: "now_playing" },
         { title: "Recently Added", key: "recently_added" },
         { title: "Queue", key: "queue" },
@@ -2151,6 +2156,7 @@ Function createHomeScreenPrefsScreen(viewController) As Object
     obj.AddItem({title: "Queue"}, "playlist_view_queue", obj.GetEnumValue("playlist_view_queue"))
     obj.AddItem({title: "Recommendations"}, "playlist_view_recommendations", obj.GetEnumValue("playlist_view_recommendations"))
     obj.AddItem({title: "On Deck"}, "row_visibility_ondeck", obj.GetEnumValue("row_visibility_ondeck"))
+    obj.AddItem({title: "Playlists"}, "row_visibility_playlists", obj.GetEnumValue("row_visibility_playlists"))
     obj.AddItem({title: "Recently Added"}, "row_visibility_recentlyadded", obj.GetEnumValue("row_visibility_recentlyadded"))
     obj.AddItem({title: "Now Playing"}, "row_visibility_now_playing", obj.GetEnumValue("row_visibility_now_playing"))
     obj.AddItem({title: "Channels"}, "row_visibility_channels", obj.GetEnumValue("row_visibility_channels"))
@@ -2172,7 +2178,7 @@ Function prefsHomeHandleMessage(msg) As Boolean
             m.ViewController.PopScreen(m)
         else if msg.isListItemSelected() then
             command = m.GetSelectedCommand(msg.GetIndex())
-            if command = "playlist_view_queue" OR command = "playlist_view_recommendations" OR command = "row_visibility_ondeck" OR command = "row_visibility_recentlyadded" OR command = "row_visibility_channels" or command = "row_visibility_now_playing" or command = "rf_home_displaymode" or command = "rf_hs_clock" or command = "rf_hs_date" then
+            if command = "playlist_view_queue" OR command = "playlist_view_recommendations" OR command = "row_visibility_ondeck" OR command = "row_visibility_playlists" OR command = "row_visibility_recentlyadded" OR command = "row_visibility_channels" or command = "row_visibility_now_playing" or command = "rf_home_displaymode" or command = "rf_hs_clock" or command = "rf_hs_date" then
                 m.HandleEnumPreference(command, msg.GetIndex())
             else if command = "home_row_order" then
                 m.HandleReorderPreference(command, msg.GetIndex())

--- a/Plex/source/ViewController.brs
+++ b/Plex/source/ViewController.brs
@@ -502,6 +502,11 @@ Function vcCreateScreenForItem(context, contextIndex, breadcrumbs, show=true) As
         screen = createGridScreenForItem(item, m, "flat-16x9") ' not really sure where this is ( maybe the myPlex queue )
         screenName = "Playlist Grid"
         if screen.loader.focusrow <> invalid then screen.loader.focusrow = 2 ' hide header row ( flat-16x9 is 5x3 )
+    else if contentType = "playlist" then
+        screen = createPosterScreen(item, m)
+        screen.SetListStyle("flat-episodic", "zoom-to-fill")
+        screenName = "Playlist Grid"
+    else if contentType = "photo" then
     else if contentType = "photo" then
         if right(item.key, 8) = "children" then
             if poster_grid = "grid" then 

--- a/Plex/source/generalUtils.brs
+++ b/Plex/source/generalUtils.brs
@@ -468,11 +468,12 @@ End Function
 '******************************************************
 'Return the first valid argument
 '******************************************************
-Function firstOf(first, second, third=invalid, fourth=invalid)
+Function firstOf(first, second, third=invalid, fourth=invalid, fifth=invalid)
     if first <> invalid then return first
     if second <> invalid then return second
     if third <> invalid then return third
-    return fourth
+    if fourth <> invalid then return fourth
+    return fifth
 End Function
 
 '******************************************************


### PR DESCRIPTION
Here's my attempt at Playlists support. This adds a HomeScreen item for listing out configured playlists. You can select a play list and get a list of items to play. Right now I'm not filtering out the type of playlists. I'm also not happy with keeping the listview up to date when the playlist is playing. 

![roku_rarflix_playlists_home](https://cloud.githubusercontent.com/assets/884816/4086460/84d457e0-2f36-11e4-981e-0fb4f09a0a17.jpg)

![roku_rarflix_playlists](https://cloud.githubusercontent.com/assets/884816/4086462/89002e52-2f36-11e4-98ee-a60c031c41d3.jpg)

I'm new to Roku Plex/RARflix development and am sure this has problems. 

But, it works at my house on my Roku 2 XS with a QNAP (Intel) PMS 0.9.9.14.5 backend.
