### PR TITLE
Fix remote playback issue with current Plex server & iOS app

### DIFF
--- a/Plex/manifest
+++ b/Plex/manifest
@@ -1,8 +1,8 @@
 title=RARflix
-version=3.2.6
+version=3.2.7
 major_version=3
 minor_version=2
-build_version=6
+build_version=7
 subtitle=The best personal and online content streaming app!
 description=Plex delivers the best video, music and photo streaming media experience that connects you to any online or personal content--including movies, TV shows, videos, music and photos.  Plex for Roku works with myPlex and the your personal Plex Media Server enabling Plex Channels, Social Sharing, and Queueing of content.
 mm_icon_focus_hd=pkg:/images/plex-logo-hd-rarflix.jpg

--- a/Plex/manifest.rarflix.template
+++ b/Plex/manifest.rarflix.template
@@ -1,8 +1,8 @@
 title=APPTITLE
-version=3.2.6
+version=3.2.7
 major_version=3
 minor_version=2
-build_version=6
+build_version=7
 subtitle=The best personal and online content streaming app!
 description=Plex delivers the best video, music and photo streaming media experience that connects you to any online or personal content--including movies, TV shows, videos, music and photos.  Plex for Roku works with myPlex and the your personal Plex Media Server enabling Plex Channels, Social Sharing, and Queueing of content.
 mm_icon_focus_hd=pkg:/images/plex-logo-hd-rarflix.jpg

--- a/Plex/manifest.rarflixDEV.template
+++ b/Plex/manifest.rarflixDEV.template
@@ -1,8 +1,8 @@
 title=APPTITLE
-version=3.1.45
+version=3.2.7
 major_version=3
-minor_version=1
-build_version=45
+minor_version=2
+build_version=7
 subtitle=The best personal and online content streaming app!
 description=Plex delivers the best video, music and photo streaming media experience that connects you to any online or personal content--including movies, TV shows, videos, music and photos.  Plex for Roku works with myPlex and the your personal Plex Media Server enabling Plex Channels, Social Sharing, and Queueing of content.
 mm_icon_focus_hd=pkg:/images/plex-logo-hd-rarflix-DEV.jpg

--- a/Plex/source/PlexContainer.brs
+++ b/Plex/source/PlexContainer.brs
@@ -75,132 +75,134 @@ Sub containerParseXml()
     end if
 
     nodes = m.xml.GetChildElements()
-    for each n in nodes
-        nodeType = firstOf(n@type, m.ViewGroup)
+    if (nodes <> invalid) then
+        for each n in nodes
+            nodeType = firstOf(n@type, m.ViewGroup)
 
-        if n@scanner <> invalid OR n@agent <> invalid then
-            metadata = newDirectoryMetadata(m, n)
-            metadata.contentType = "section"
-            if n@thumb = invalid then
-                if metadata.Type = "movie" then
-                    thumb = imageDir + "section-movie.png"
-                else if metadata.Type = "show" then
-                    thumb = imageDir + "section-tv.png"
-                else if metadata.Type = "artist" then
-                    thumb = imageDir + "section-music.png"
-                else if metadata.Type = "photo" then
-                    thumb = imageDir + "section-photo.png"
-                else
-                    thumb = invalid
+            if n@scanner <> invalid OR n@agent <> invalid then
+                metadata = newDirectoryMetadata(m, n)
+                metadata.contentType = "section"
+                if n@thumb = invalid then
+                    if metadata.Type = "movie" then
+                        thumb = imageDir + "section-movie.png"
+                    else if metadata.Type = "show" then
+                        thumb = imageDir + "section-tv.png"
+                    else if metadata.Type = "artist" then
+                        thumb = imageDir + "section-music.png"
+                    else if metadata.Type = "photo" then
+                        thumb = imageDir + "section-photo.png"
+                    else
+                        thumb = invalid
+                    end if
+
+                    if thumb <> invalid then
+                        metadata.SDPosterURL = thumb
+                        metadata.HDPosterURL = thumb
+                        metadata.CompositionMode = "Source_Over"
+                    end if
+                end if
+            else if nodeType = "artist" OR n.GetName() = "Artist" then
+                metadata = newArtistMetadata(m, n, m.ParseDetails)
+            else if nodeType = "album" OR n.GetName() = "Album" then
+                metadata = newAlbumMetadata(m, n, m.ParseDetails)
+            else if nodeType = "season" then
+                metadata = newSeasonMetadata(m, n)
+            else if nodeType = "Store:Info" then
+                metadata = newChannelMetadata(m, n)
+            else if n@search = "1" then
+                metadata = newSearchMetadata(m, n)
+            else if n.GetName() = "Directory" then
+                metadata = newDirectoryMetadata(m, n)       
+            else if nodeType = "movie" OR nodeType = "episode" then
+                metadata = newVideoMetadata(m, n, m.ParseDetails)
+            else if nodeType = "clip" OR n.GetName() = "Video" then
+                ' Video in a channel, use the regular video metadata
+                metadata = newVideoMetadata(m, n, m.ParseDetails)
+            else if nodeType = "track" OR n.GetName() = "Track" then
+                metadata = newTrackMetadata(m, n, m.ParseDetails)
+            else if nodeType = "photo" OR n.GetName() = "Photo" then
+                metadata = newPhotoMetadata(m, n, m.ParseDetails)
+            else if n.GetName() = "Setting" then
+                metadata = newSettingMetadata(m, n)
+            else
+                metadata = newDirectoryMetadata(m, n)
+            end if
+
+            ' ljunkie - custom posters/thumbs for items the PMS does not give a thumb for
+            ' I had some crazy logic if the thumb existing thumb was local or a /libary/metadata/etc.. 
+            ' it seems though it's safe to assume if the PMS doesn't give a thumb then we can replace it
+            ' if the PMS starts giving out generic thumbs, I'll have to repace with the crazy logic/regex
+
+            if RegRead("rf_custom_thumbs", "preferences","enabled") = "enabled" then
+                rfHasThumb = firstof(n@thumb, n@grandparentThumb, n@parentThumb)
+               ' any other resources we want to override below
+                re = CreateObject("roRegex", "/:/resources/actor-icon|resources/Book1.png", "") 
+                ' this has mixed results - really the channel provider should be adding custom thumbs for every directory instead of the base channel thumb
+                ' I.E. youtube, cbs.. ( for now it's disabled - Toggle is ready, but I am not ready for the outcome -- I.E. use it for "this" channel, and not "that" channel, etc..) 
+                if RegRead("rf_channel_text", "preferences","disabled") <> "disabled" and nodetype = invalid then
+                    rfHasThumb = invalid
                 end if
 
-                if thumb <> invalid then
-                    metadata.SDPosterURL = thumb
-                    metadata.HDPosterURL = thumb
-                    metadata.CompositionMode = "Source_Over"
+                ' for now, I am not going to override these
+                remusic = CreateObject("roRegex", "resources%2Fartist.png", "") 
+                if tostr(nodeType) =  "track" or tostr(nodeType) = "album" then
+                  rfHasThumb = "skip"
+                  if remusic.isMatch(tostr(metadata.HDPosterURL)) then rfHasThumb = invalid
                 end if
-            end if
-        else if nodeType = "artist" OR n.GetName() = "Artist" then
-            metadata = newArtistMetadata(m, n, m.ParseDetails)
-        else if nodeType = "album" OR n.GetName() = "Album" then
-            metadata = newAlbumMetadata(m, n, m.ParseDetails)
-        else if nodeType = "season" then
-            metadata = newSeasonMetadata(m, n)
-        else if nodeType = "Store:Info" then
-            metadata = newChannelMetadata(m, n)
-        else if n@search = "1" then
-            metadata = newSearchMetadata(m, n)
-        else if n.GetName() = "Directory" then
-            metadata = newDirectoryMetadata(m, n)       
-        else if nodeType = "movie" OR nodeType = "episode" then
-            metadata = newVideoMetadata(m, n, m.ParseDetails)
-        else if nodeType = "clip" OR n.GetName() = "Video" then
-            ' Video in a channel, use the regular video metadata
-            metadata = newVideoMetadata(m, n, m.ParseDetails)
-        else if nodeType = "track" OR n.GetName() = "Track" then
-            metadata = newTrackMetadata(m, n, m.ParseDetails)
-        else if nodeType = "photo" OR n.GetName() = "Photo" then
-            metadata = newPhotoMetadata(m, n, m.ParseDetails)
-        else if n.GetName() = "Setting" then
-            metadata = newSettingMetadata(m, n)
-        else
-            metadata = newDirectoryMetadata(m, n)
-        end if
-
-        ' ljunkie - custom posters/thumbs for items the PMS does not give a thumb for
-        ' I had some crazy logic if the thumb existing thumb was local or a /libary/metadata/etc.. 
-        ' it seems though it's safe to assume if the PMS doesn't give a thumb then we can replace it
-        ' if the PMS starts giving out generic thumbs, I'll have to repace with the crazy logic/regex
-
-        if RegRead("rf_custom_thumbs", "preferences","enabled") = "enabled" then
-            rfHasThumb = firstof(n@thumb, n@grandparentThumb, n@parentThumb)
-           ' any other resources we want to override below
-            re = CreateObject("roRegex", "/:/resources/actor-icon|resources/Book1.png", "") 
-            ' this has mixed results - really the channel provider should be adding custom thumbs for every directory instead of the base channel thumb
-            ' I.E. youtube, cbs.. ( for now it's disabled - Toggle is ready, but I am not ready for the outcome -- I.E. use it for "this" channel, and not "that" channel, etc..) 
-            if RegRead("rf_channel_text", "preferences","disabled") <> "disabled" and nodetype = invalid then
-                rfHasThumb = invalid
-            end if
-
-            ' for now, I am not going to override these
-            remusic = CreateObject("roRegex", "resources%2Fartist.png", "") 
-            if tostr(nodeType) =  "track" or tostr(nodeType) = "album" then
-              rfHasThumb = "skip"
-              if remusic.isMatch(tostr(metadata.HDPosterURL)) then rfHasThumb = invalid
-            end if
-                  
-            PrintDebug = false
-            if rfHasThumb = invalid or re.isMatch(rfHasThumb) then 
-                thumb_text = firstof(metadata.umtitle, metadata.title)
-                if thumb_text <> invalid AND metadata.server <> invalid then
-                    if PrintDebug then 
+                      
+                PrintDebug = false
+                if rfHasThumb = invalid or re.isMatch(rfHasThumb) then 
+                    thumb_text = firstof(metadata.umtitle, metadata.title)
+                    if thumb_text <> invalid AND metadata.server <> invalid then
+                        if PrintDebug then 
+                            Debug( "-------------------------------------------")
+                            Debug("---- using custom thumb from rarflix cloudfrount service with title:" + firstof(metadata.umtitle, metadata.title))
+                            Debug("---- viewGroup:" + tostr(metadata.ViewGroup) + " nodeType:" + tostr(nodeType))
+                            Debug("---- Original:" + tostr(metadata.HDPosterURL))
+                        end if
+                        rfCDNthumb(metadata,thumb_text,nodetype,PrintDebug)
+                    else if PrintDebug then  
                         Debug( "-------------------------------------------")
-                        Debug("---- using custom thumb from rarflix cloudfrount service with title:" + firstof(metadata.umtitle, metadata.title))
+                        Debug("---- NOT using custom thumb due to the below? we have skipped it due to the data below")
                         Debug("---- viewGroup:" + tostr(metadata.ViewGroup) + " nodeType:" + tostr(nodeType))
                         Debug("---- Original:" + tostr(metadata.HDPosterURL))
+                        Debug( "-------------------------------------------")
                     end if
-                    rfCDNthumb(metadata,thumb_text,nodetype,PrintDebug)
-                else if PrintDebug then  
-                    Debug( "-------------------------------------------")
-                    Debug("---- NOT using custom thumb due to the below? we have skipped it due to the data below")
-                    Debug("---- viewGroup:" + tostr(metadata.ViewGroup) + " nodeType:" + tostr(nodeType))
-                    Debug("---- Original:" + tostr(metadata.HDPosterURL))
-                    Debug( "-------------------------------------------")
-                end if
-            else if PrintDebug then 
-                isLocal = CreateObject("roRegex", "127.0.0.1", "") ' TODO: any other than actor_con? these are default template.. ignore them
-                if NOT isLocal.isMatch(rfHasThumb) then 
-                    Debug( "-------------------------------------------")
-                    Debug("---- NOT using custom thumb for valid image")
-                    Debug("---- viewGroup:" + tostr(metadata.ViewGroup) + " nodeType:" + tostr(nodeType))
-                    Debug("---- Original:" + tostr(metadata.HDPosterURL))
-                    Debug( "-------------------------------------------")
+                else if PrintDebug then 
+                    isLocal = CreateObject("roRegex", "127.0.0.1", "") ' TODO: any other than actor_con? these are default template.. ignore them
+                    if NOT isLocal.isMatch(rfHasThumb) then 
+                        Debug( "-------------------------------------------")
+                        Debug("---- NOT using custom thumb for valid image")
+                        Debug("---- viewGroup:" + tostr(metadata.ViewGroup) + " nodeType:" + tostr(nodeType))
+                        Debug("---- Original:" + tostr(metadata.HDPosterURL))
+                        Debug( "-------------------------------------------")
+                    end if
                 end if
             end if
-        end if
-        ' END custom poster/thumbs
+            ' END custom poster/thumbs
 
-        PosterIndicators(metadata)
+            PosterIndicators(metadata)
 
-        ' ljunkie - check if HomeVideo. This will be used to limit or change options since HomeVideos don't work with certain features.
-        ' I.E. cast & crew, trailers. The thumbnail size will also be landscape instead of a poster
-        ' check specific item for librarySectionUUID or fall back to contents librarySectionUUID
-        if n@librarySectionUUID <> invalid then 
-            metadata.isHomeVideos = GetGlobalAA().lookup("lsHomeVideos_"+n@librarySectionUUID)
-        else if m.xml@librarySectionUUID <> invalid then 
-            metadata.isHomeVideos = GetGlobalAA().lookup("lsHomeVideos_"+m.xml@librarySectionUUID)
-        end if
+            ' ljunkie - check if HomeVideo. This will be used to limit or change options since HomeVideos don't work with certain features.
+            ' I.E. cast & crew, trailers. The thumbnail size will also be landscape instead of a poster
+            ' check specific item for librarySectionUUID or fall back to contents librarySectionUUID
+            if n@librarySectionUUID <> invalid then 
+                metadata.isHomeVideos = GetGlobalAA().lookup("lsHomeVideos_"+n@librarySectionUUID)
+            else if m.xml@librarySectionUUID <> invalid then 
+                metadata.isHomeVideos = GetGlobalAA().lookup("lsHomeVideos_"+m.xml@librarySectionUUID)
+            end if
 
-        if metadata.search = true AND m.SeparateSearchItems then
-            m.search.Push(metadata)
-        else if metadata.setting = true then
-            m.settings.Push(metadata)
-        else
-            m.metadata.Push(metadata)
-            m.names.Push(metadata.Title)
-            m.keys.Push(metadata.Key)
-        end if
-    next
+            if metadata.search = true AND m.SeparateSearchItems then
+                m.search.Push(metadata)
+            else if metadata.setting = true then
+                m.settings.Push(metadata)
+            else
+                m.metadata.Push(metadata)
+                m.names.Push(metadata.Title)
+                m.keys.Push(metadata.Key)
+            end if
+        next
+    end if
 
     ' ljunkie - from ROKU -- this can be a memmory issue. So after we parse the XML, we invalidate it.
     m.xml = invalid ' cleanup XML -- it's parsed now

--- a/Plex/source/ViewController.brs
+++ b/Plex/source/ViewController.brs
@@ -1133,6 +1133,11 @@ Sub vcShowReleaseNotes(options = invalid)
         ' We have a scrollable text screen now - we can include all the updates - yay
         us = "_______________"
         paragraphs.Push("  ")
+        paragraphs.Push(us+"v3.2.7 (2015-12-07)"+us)
+        paragraphs.Push("  ")
+        paragraphs.Push(" * @mikeh: Remote playback fixes")
+        paragraphs.Push("  ")
+
         paragraphs.Push(us+"v3.2.6 (2014-08-16)"+us)
         paragraphs.Push("  ")
         paragraphs.Push(" * Fix trailers (youtube)")

--- a/Plex/source/webserver/request.brs
+++ b/Plex/source/webserver/request.brs
@@ -109,10 +109,11 @@ function request_parse(conn as Object) as Boolean
 
             ' parse query string if present
             m.query = CreateObject("roAssociativeArray")
-            parts = m.uri.tokenize("?")
-            if parts.count() = 2
-                m.path = parts.GetHead()
-                args = parts.GetTail().tokenize("&")
+' @mikeh: URI parsing fix for remote playback control
+            querypos = m.uri.instr("?")
+            if (querypos > 0) then
+                m.path = m.uri.left(querypos)
+                args = m.uri.mid(querypos+1).tokenize("&")
                 for each arg in args
                     av = arg.tokenize("=")
                     if av.count()=2 then m.query[UrlUnescape(av.GetHead())] = UrlUnescape(av.GetTail())


### PR DESCRIPTION
The issue was tracked down to the URI parsing code in source/webserver/request.brs which couldn't handle the case when two "?"s appeared in the URI. This seems to be the case with the current public Plex server (0.9.12.19) due to a parameter `containerKey=/playQueues/42?own%3D1%26window%3D200`
